### PR TITLE
(fix) add user agent to request headers

### DIFF
--- a/mfp_functions/fetchDateRange.js
+++ b/mfp_functions/fetchDateRange.js
@@ -8,7 +8,14 @@ var fetchDateRange = function(username, startDate, endDate, fields, callback){
   //get MyFitnessPal URL (eg. 'http://www.myfitnesspal.com/reports/printable_diary/npmmfp?from=2014-09-13&to=2014-09-17')
   var url = helpers.mfpUrl(username, startDate, endDate);
 
-  request(url, function(error, response, body) {
+  var options = {
+    url: url,
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+    }
+  };
+
+  request(options, function(error, response, body) {
     if (error) throw error;
 
     var $ = cheerio.load(body); //load DOM from HTML file

--- a/mfp_functions/fetchSingleDate.js
+++ b/mfp_functions/fetchSingleDate.js
@@ -8,7 +8,14 @@ var fetchSingleDate = function(username, date, fields, callback){
   //get MyFitnessPal URL (eg. 'http://www.myfitnesspal.com/reports/printable_diary/npmmfp?from=2014-09-13&to=2014-09-13')
   var url = helpers.mfpUrl(username, date, date);
 
-  request(url, function(error, response, body) {
+  var options = {
+    url: url,
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+    }
+  };
+
+  request(options, function(error, response, body) {
     if (error) throw error;
 
     var $ = cheerio.load(body);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mfp",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A third-party API for accessing MyFitnessPal diary data",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Problem**
- requests failing because of lack of user agent string

**Solution**
- add user agent header to requests

**Testing**
- verified working on local

**Reviewers**
- @arthurzey
- @tgvarik