### PR TITLE
Added User-Agent request header to diaryStatusCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ gulp watch
 * 0.5.3 Fix Bug: diaryStatusCheck correctly returns 'invalid user' when hitting 404 page
 * 0.5.4 Update dependencies, update tests to use mocha's done() for async tests
 * 0.5.5 Add User Agent String to Request Headers to Fix Failing Scraping
+* 0.5.6 Add User-Agent String to Request Headers of checking if diary is public
 
 # Known Issues
 

--- a/mfp_functions/diaryStatusCheck.js
+++ b/mfp_functions/diaryStatusCheck.js
@@ -8,7 +8,14 @@ var diaryStatusCheck = function(username, callback){
   //get MyFitnessPal URL (eg. 'http://www.myfitnesspal.com/reports/printable_diary/npmmfp')
   var url = helpers.mfpUrl(username);
 
-  request(url, function(error, response, body) {
+  var options = {
+    url: url,
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36'
+    }
+  };
+
+  request(options, function(error, response, body) {
     if (error) throw error;
 
     var $ = cheerio.load(body);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mfp",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "A third-party API for accessing MyFitnessPal diary data",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Problem
myfitnesspal.com rejects requests that don't have a User-Agent request header specified, making it impossible for freemydiary.com to check whether the specified user has a public diary.

# Solution
Add a User-Agent request header for this check.

# Testing
None. I'm cowboying it. @andrewzey, do you want to do this or instruct me on how to do this? :D
